### PR TITLE
performance: directStream option

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -438,6 +438,9 @@ module.exports = function(proto) {
           captureStdout: !outputStream,
           niceness: self.options.niceness,
           cwd: self.options.cwd,
+          stdio: Boolean(self._currentOutput.pipeopts.directStream)
+            ? ['pipe', self._currentOutput.target, 'pipe']
+            : undefined,
           windowsHide: true
         }, 
 
@@ -475,7 +478,9 @@ module.exports = function(proto) {
 
           if (outputStream) {
             // Pipe ffmpeg stdout to output stream
-            ffmpegProc.stdout.pipe(outputStream.target, outputStream.pipeopts);
+            if (!outputStream.pipeopts.directStream) {
+              ffmpegProc.stdout.pipe(outputStream.target, outputStream.pipeopts);
+            }
 
             // Handle output stream events
             outputStream.target.on('close', function() {


### PR DESCRIPTION
This adds an option to pipe ffmpeg process's stdout directly into the target input stream. Stream must have an underlying file descriptor.

See https://nodejs.org/api/child_process.html#child_process_options_stdio