### PR TITLE
Remove dynamic module-loading preset behavior

### DIFF
--- a/lib/options/misc.js
+++ b/lib/options/misc.js
@@ -22,18 +22,7 @@ module.exports = function(proto) {
     if (typeof preset === 'function') {
       preset(this);
     } else {
-      try {
-        var modulePath = path.join(this.options.presets, preset);
-        var module = require(modulePath);
-
-        if (typeof module.load === 'function') {
-          module.load(this);
-        } else {
-          throw new Error('preset ' + modulePath + ' has no load() function');
-        }
-      } catch (err) {
-        throw new Error('preset ' + modulePath + ' could not be loaded: ' + err.message);
-      }
+      throw new Error('Module-loading `preset` not supported');
     }
 
     return this;


### PR DESCRIPTION
The dynamic preset-loading behavior is not compatible with the way that we package fluent-ffmpeg, so we will just throw an error in that case.