### PR TITLE
Fixing capability parsing for ffmpeg 6+

### DIFF
--- a/doc/capabilities.js.html
+++ b/doc/capabilities.js.html
@@ -42,7 +42,7 @@ var ffCodecRegexp = /^\s*([D\.])([E\.])([VAS])([I\.])([L\.])([S\.]) ([^ ]+) +(.*
 var ffEncodersRegexp = /\(encoders:([^\)]+)\)/;
 var ffDecodersRegexp = /\(decoders:([^\)]+)\)/;
 var encodersRegexp = /^\s*([VAS\.])([F\.])([S\.])([X\.])([B\.])([D\.]) ([^ ]+) +(.*)$/;
-var formatRegexp = /^\s*([D ])([E ]) ([^ ]+) +(.*)$/;
+var formatRegexp = /^\s*([D ])([E ])[d ]?\s+([^ ]+) +(.*)$/;
 var lineBreakRegexp = /\r\n|\r|\n/;
 var filterRegexp = /^(?: [T\.][S\.][C\.] )?([^ ]+) +(AA?|VV?|\|)->(AA?|VV?|\|) +(.*)$/;
 

--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -15,7 +15,7 @@ var ffCodecRegexp = /^\s*([D\.])([E\.])([VAS])([I\.])([L\.])([S\.]) ([^ ]+) +(.*
 var ffEncodersRegexp = /\(encoders:([^\)]+)\)/;
 var ffDecodersRegexp = /\(decoders:([^\)]+)\)/;
 var encodersRegexp = /^\s*([VAS\.])([F\.])([S\.])([X\.])([B\.])([D\.]) ([^ ]+) +(.*)$/;
-var formatRegexp = /^\s*([D ])([E ]) ([^ ]+) +(.*)$/;
+var formatRegexp = /^\s*([D ])([E ])[d ]?\s+([^ ]+) +(.*)$/;
 var lineBreakRegexp = /\r\n|\r|\n/;
 var filterRegexp = /^(?: [T\.][S\.][C\.] )?([^ ]+) +(AA?|VV?|\|)->(AA?|VV?|\|) +(.*)$/;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descript/fluent-ffmpeg",
-  "version": "2.1.2-descript.5",
+  "version": "2.1.3-descript.1",
   "description": "A fluent API to FFMPEG (http://www.ffmpeg.org)",
   "keywords": [
     "ffmpeg"

--- a/test/capabilities.test.js
+++ b/test/capabilities.test.js
@@ -72,6 +72,14 @@ describe('Capabilities', function() {
         ('canDemux' in formats.wav).should.equal(true);
         (typeof formats.wav.canDemux).should.equal('boolean');
 
+        ('lavfi' in formats).should.equal(true);
+        ('description' in formats.lavfi).should.equal(true);
+        (typeof formats.lavfi.description).should.equal('string');
+        ('canMux' in formats.lavfi).should.equal(true);
+        (typeof formats.lavfi.canMux).should.equal('boolean');
+        ('canDemux' in formats.lavfi).should.equal(true);
+        (typeof formats.lavfi.canDemux).should.equal('boolean');
+
         done();
       });
     });


### PR DESCRIPTION
Creating a new release for fluent-ffmpeg to support FFMPEG versions 6.1.1 and above where the capability output stream format has changed a little. This is causing misdetection for available formats within ffmpeg.